### PR TITLE
Fix typo in dissmiss-stale-reviews

### DIFF
--- a/.github/repos/settings.yaml
+++ b/.github/repos/settings.yaml
@@ -13,7 +13,7 @@
 
 shared-config: &shared-config
   branch-protection:
-    dismiss-stale-reviews: false
+    dissmiss-stale-reviews: false
     required-review-count: 2
   protect-default-branch: true
   features:


### PR DESCRIPTION
The script reposettings.py has a bit of mess:
https://github.com/roobre/reposettings/blob/4622b897e769b3008bbcab99b68cf6cd5b90c02d/reposettings.py#L154
> 'dissmiss-stale-reviews' VS 'dismiss_stale_reviews'.
The correct YAML option name is 'dissmiss-stale-reviews'. It changes nothing for repos, as the current value 'false' matches to GitHub defaults, but good to be in sync.

Reported it as an issue upstream: https://github.com/roobre/reposettings/issues/7