### PR TITLE
Update renovate juju agent regex

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -75,7 +75,7 @@
   "regexManagers": [
     {
       "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
-      "matchStrings": ["juju-agent-version: (?<currentValue>[0-9.]+)"],
+      "matchStrings": ["(?<currentValue>[0-9.]+) +# renovate: juju-agent-pin-major"],
       "depNameTemplate": "juju/juju",
       "extractVersionTemplate": "^juju-(?<version>.*)$",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
Juju agent version could be part of GitHub matrix

Example: https://github.com/canonical/mysql-operator/blob/33d7c551a7f2d40932bfb551177d0a930f9f8375/.github/workflows/ci.yaml#L67-L68