### PR TITLE
Use a separate group for Python updates in renovate preset

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -38,6 +38,13 @@
       "commitMessagePrefix": "[python ci]",
       "groupName": "Python CI dependencies"
     },
+    // Use a separate group for Python updates
+    {
+      "matchManagers": ["poetry"],
+      "matchDepTypes": ["dependencies"],
+      "matchPackageNames": ["python"],
+      "groupName": "Python"
+    },
     // Group data-platform-workflows Python package & workflow updates into the same PR
     {
       "matchManagers": ["poetry"],


### PR DESCRIPTION
Python version depends on charm base, which is not updated at the same time as other Python dependencies