### PR TITLE
Reduce charm Renovate groups

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -35,6 +35,10 @@
       "matchPackageNames": ["python"],
       "groupName": "Python"
     },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub actions"
+    },
     // Group data-platform-workflows Python package & workflow updates into the same PR
     {
       "matchManagers": ["poetry"],


### PR DESCRIPTION
Combine
- charm dependencies
- charm lib dependencies
- Python CI dependencies 

into a single Renovate group so that they will be combined into 1 PR. (Major version updates will still be separated into a different PR)

Combine GitHub actions updates into 1 group

Purpose: to reduce number of PRs that renovate creates (to reduce # of PR reviews and # of test runs [especially annoying with flaky tests])