### PR TITLE
Disable Python version updates in renovate preset

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -27,13 +27,14 @@
       "rangeStrategy": "in-range-only",
       "groupName": "Python dependencies"
     },
-    // Use a separate group for Python updates
+    // Disable Python updates
+    // (Python version should be updated when Ubuntu version is updated)
     {
       "matchManagers": ["poetry"],
       // Renovate uses "dependencies" instead of "main" for top-level dependency group
       "matchDepTypes": ["dependencies"],
       "matchPackageNames": ["python"],
-      "groupName": "Python"
+      "enabled": false
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
removes need for https://github.com/canonical/postgresql-operator/blob/c34b78d4f9bfd4e6022a414149290440abc066bd/.github/renovate.json5#L11-L12 to stop renovate from opening PRs to update Python version