### PR TITLE
Disable minor juju version updates in renovate preset

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -66,18 +66,18 @@
       "matchPackageNames": ["juju/juju"],
       "groupName": "Juju agents"
     },
-    // Disable major version updates for Juju agent (they should be handled manually)
+    // Disable major & minor version updates for Juju agent (they should be handled manually)
     {
       "matchManagers": ["regex"],
       "matchPackageNames": ["juju/juju"],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
   ],
   "regexManagers": [
     {
       "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
-      "matchStrings": ["(?<currentValue>[0-9.]+) +# renovate: juju-agent-pin-major"],
+      "matchStrings": ["(?<currentValue>[0-9.]+) +# renovate: juju-agent-pin-minor"],
       "depNameTemplate": "juju/juju",
       "extractVersionTemplate": "^juju-(?<version>.*)$",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
For juju 3.1, we're currently pinning minor (and postgresql renovate config is manually accomplishing this with upper limit https://github.com/canonical/postgresql-operator/blob/fabce2592598d933397ec14bd836386e159dfe50/.github/renovate.json5#L24)

It seems like we should just be pinning major & minor version in the first place, and require manual PRs to update minor Juju version

Context: https://github.com/canonical/mysql-operator/pull/457#discussion_r1627238802

This renovate config also allows all Juju agent versions to be updated in the same renovate PR