### PR TITLE
[MISC] Enable patch versions for agent pins

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -64,7 +64,8 @@
     {
       "matchManagers": ["regex"],
       "matchPackageNames": ["juju/juju"],
-      "groupName": "Juju agents"
+      "groupName": "Juju agents",
+      "separateMinorPatch": true
     },
     // Disable major & minor version updates for Juju agent (they should be handled manually)
     {


### PR DESCRIPTION
Agent pins didn't update.

Tested on https://github.com/dragomirp/postgresql-k8s-operator/pull/4