### PR TITLE
[MISC] Match python by depname

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -33,7 +33,7 @@
       "matchManagers": ["poetry"],
       // Renovate uses "dependencies" instead of "main" for top-level dependency group
       "matchDepTypes": ["dependencies"],
-      "matchPackageNames": ["python"],
+      "matchDepNames": ["python"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Python dependency still gets updated, renovate uses `containerbase/python-prebuild` as package name.

Tested on https://github.com/dragomirp/pgbouncer-k8s-operator/pull/1