### PR TITLE
Update renovate config for charmcraft.yaml build tools

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -80,10 +80,9 @@
       "pinDigests": true,
       "groupName": "OCI digests"
     },
-    // Update build tools in charmcraft.yaml
     {
       "matchManagers": ["regex"],
-      "matchDepNames": ["pip", "uv", "python3.10", "poetry", "poetry-plugin-export"],
+      "matchFileNames": ["charmcraft.yaml"],
       "groupName": "charmcraft.yaml build tools"
     }
   ],


### PR DESCRIPTION
Example charmcraft.yaml excerpt
```yaml
  poetry-deps:
    plugin: nil
    build-packages:
      - curl
    override-build: |
      # Use environment variable instead of `--break-system-packages` to avoid failing on older
      # versions of pip that do not recognize `--break-system-packages`
      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==24.3.1  # renovate: charmcraft-pip-latest

      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
      # poetry 2.0.0 requires Python >=3.9
      if ! "$HOME/.local/bin/uv" python find '>=3.9'
      then
        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
        # (to reduce number of Python versions we use)
        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
      fi
      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.0.0 --with poetry-plugin-export==1.8.0  # renovate: charmcraft-poetry-latest

      ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
```