### PR TITLE
Add renovate config for rust version

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -162,6 +162,15 @@
       "matchStrings": ["poetry-plugin-export==(?<currentValue>[^ ]+)[^\\n]* # renovate: charmcraft-poetry-latest"],
       "depNameTemplate": "poetry-plugin-export",
       "datasourceTemplate": "pypi"
+    },
+    // Update rust version in charmcraft.yaml
+    {
+      "customType": "regex",
+      "fileMatch": ["^charmcraft\\.yaml$"],
+      "matchStrings": [" (?<currentValue>[^ ]+) +# renovate: charmcraft-rust-latest"],
+      "packageNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
Example charmcraft.yaml excerpt
```yaml
    override-build: |
      # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
      # archive—which means the rustup version could be updated at any time. Print rustup version
      # to build log to make changes to the snap's rustup version easier to track
      rustup --version

      # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
      # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
      rustup set profile minimal
      rustup default 1.83.0  # renovate: charmcraft-rust-latest

      craftctl default
      # Include requirements.txt in *.charm artifact for easier debugging
      cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
```