### PR TITLE
Add `not bug or enhancement` label to PRs

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -13,6 +13,8 @@
     "schedule": ["after 1am and before 3am every weekday"]
   },
   "timezone": "Etc/UTC",
+  // Exclude Renovate PRs from auto-generated release notes
+  "labels": ["not bug or enhancement"],
   "enabledManagers": ["poetry", "github-actions", "regex"],
   "packageRules": [
     // Later rules override earlier rules


### PR DESCRIPTION
Used to exclude Renovate PRs from auto-generated release notes