### PR TITLE
Run renovate once per week

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -7,10 +7,10 @@
     // Avoid conflicts with custom `commitMessagePrefix`
     ":semanticCommitsDisabled"
   ],
-  "schedule": ["after 1am and before 3am every weekday"],
+  "schedule": ["* 1-5 * * 2"],  // Tuesday 01:00-05:00 UTC
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["after 1am and before 3am every weekday"]
+    "schedule": ["* 1-5 * * 2"]  // Tuesday 01:00-05:00 UTC
   },
   "timezone": "Etc/UTC",
   // Exclude Renovate PRs from auto-generated release notes


### PR DESCRIPTION
for vulnerability updates to get a PR immediately (instead of once a week), these steps must be followed: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts

notably:
- on forks and private repos, the dependency graph needs to be enabled: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#enabling-the-dependency-graph
- on all repos, Dependabot alerts need to be enabled: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository
- the GitHub Renovate app must be installed with read permissions for dependabot alerts

from testing, it appears the [removal of support for python 3.8](https://github.blog/changelog/2025-02-05-dependabot-no-longer-supports-python-3-8/) only applies to "Dependabot security updates", not "Dependabot alerts"
the closing of this issue (https://github.com/dependabot/dependabot-core/issues/10817) happening on the same day day as this blog post (https://github.blog/changelog/2025-01-06-closing-down-notice-dependabot-will-no-longer-support-python-version-3-8/) appears to confirm that it applies to "Dependabot security updates"