### PR TITLE
Remove data-platform-workflows group from Renovate preset

### DIFF
--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -36,21 +36,6 @@
       "enabled": false
     },
     {"matchManagers": ["github-actions"], "groupName": "GitHub actions"},
-    // Group data-platform-workflows Python package & workflow updates into the same PR
-    {
-      "matchManagers": ["poetry"],
-      "matchPackageNames": ["canonical/data-platform-workflows"],
-      // Ensure Renovate prefers vX.0.0 tag (e.g. "v24.0.0") over vX tag (e.g. "v24") if vX.X.X tag
-      // currently in use
-      // (Matches default versioning of "github-actions" manager)
-      "versioning": "docker",
-      "groupName": "data-platform-workflows"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["canonical/data-platform-workflows"],
-      "groupName": "data-platform-workflows"
-    },
     {
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["juju/juju"],


### PR DESCRIPTION
Companion to https://github.com/canonical/data-platform-workflows/pull/343

After integration_test_charm.yaml and python/pytest_plugins are removed, dpw will no longer ship Python packages—only GitHub workflows

Remove data-platform-workflows group so that dpw updates are included in the same Renovate PR as other GitHub actions & workflows