### PR TITLE
Create `base` renovate preset

### DIFF
--- a/renovate_presets/base.json5
+++ b/renovate_presets/base.json5
@@ -7,8 +7,8 @@
     // Avoid conflicts with custom `commitMessagePrefix`
     ":semanticCommitsDisabled"
   ],
-  "schedule": ["* 1-5 * * 2"],  // Tuesday 01:00-05:00 UTC
-  "lockFileMaintenance": {"enabled": true, "schedule": ["* 1-5 * * 2"]},  // Tuesday 01:00-05:00 UTC
+  "schedule": ["* 1-7 * * 2"],  // Tuesday 01:00-07:00 UTC
+  "lockFileMaintenance": {"enabled": true, "schedule": ["* 1-7 * * 2"]},  // Tuesday 01:00-07:00 UTC
   "timezone": "Etc/UTC",
   "enabledManagers": ["github-actions"],
   "packageRules": [

--- a/renovate_presets/base.json5
+++ b/renovate_presets/base.json5
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":disableRateLimiting",
+    ":noUnscheduledUpdates",
+    // Avoid conflicts with custom `commitMessagePrefix`
+    ":semanticCommitsDisabled"
+  ],
+  "schedule": ["* 1-5 * * 2"],  // Tuesday 01:00-05:00 UTC
+  "lockFileMaintenance": {"enabled": true, "schedule": ["* 1-5 * * 2"]},  // Tuesday 01:00-05:00 UTC
+  "timezone": "Etc/UTC",
+  "enabledManagers": ["github-actions"],
+  "packageRules": [
+    // Later rules override earlier rules
+
+    {"matchManagers": ["github-actions"], "groupName": "GitHub actions"},
+  ],
+}

--- a/renovate_presets/charm.json5
+++ b/renovate_presets/charm.json5
@@ -1,20 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":disableRateLimiting",
-    ":noUnscheduledUpdates",
-    // Avoid conflicts with custom `commitMessagePrefix`
-    ":semanticCommitsDisabled"
-  ],
-  "schedule": ["* 1-5 * * 2"],  // Tuesday 01:00-05:00 UTC
-  "lockFileMaintenance": {"enabled": true, "schedule": ["* 1-5 * * 2"]},  // Tuesday 01:00-05:00 UTC
-  "timezone": "Etc/UTC",
+  "extends": ["github>canonical/data-platform//renovate_presets/base.json5"],
   // Exclude Renovate PRs from auto-generated release notes
   "labels": ["not bug or enhancement"],
-  "enabledManagers": ["poetry", "github-actions", "custom.regex"],
+  "enabledManagers": ["github-actions", "poetry", "custom.regex"],
   "packageRules": [
     // Later rules override earlier rules
+
     {
       "matchManagers": ["poetry"],
       "rangeStrategy": "bump",
@@ -35,7 +27,6 @@
       "matchDepNames": ["python"],
       "enabled": false
     },
-    {"matchManagers": ["github-actions"], "groupName": "GitHub actions"},
     {
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["juju/juju"],


### PR DESCRIPTION
Will be used by data-platform-workflows, charmcraftcache-hub, etc.

Also extend renovate schedule to ensure renovate has enough time to open all PRs given our limited number of concurrent Renovate runs (free plan): https://chat.canonical.com/canonical/pl/dgtnjxwwm3b3ipgpqm4kikiury